### PR TITLE
feat: streamline Docker registry setup in CI workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,8 @@ jobs:
           options: |
             -u ${{ secrets.DOCKER_USER }}
             --private-key ./ssh_key
-            -i ${{ secrets.DOCKER_HOST }}
+            -i ${{ secrets.DOCKER_HOST }},
+            -c ssh
             -e "ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
 
       - name: "Write YAML"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,8 @@ jobs:
           inventory: |
             ${{ secrets.DOCKER_HOST }}
           options: |
-            --extra-vars ansible_ssh_user=${{ secrets.DOCKER_USER }} ansible_ssh_private_key_file=${{ secrets.DOCKER_SSH_KEY }}
+            --extra-vars ansible_ssh_user=${{ secrets.DOCKER_USER }}
+            --extra-vars ansible_ssh_private_key_file=${{ secrets.DOCKER_SSH_KEY }}
 
       - name: "Write YAML"
         id: yaml-action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: "Put private key in a file"
         run: |
-          echo "${{ secrets.DOCKER_SSH_KEY }}" > ./ssh_key
+          echo "${{ secrets.DOCKER_SSH_KEY }}" > ansible/ssh_key
           export ANSIBLE_HOST_KEY_CHECKING=False
 
       - name: Run playbook

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: "Put private key in a file"
         run: |
           echo "${{ secrets.DOCKER_SSH_KEY }}" > ansible/ssh_key
+          chmod 600 ansible/ssh_key
           export ANSIBLE_HOST_KEY_CHECKING=False
 
       - name: Run playbook

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
           directory: ansible
           options: |
             -u ${{ secrets.DOCKER_USER }}
-            -v ${{ secrets.DOCKER_SSH_KEY }}
+            --private-key ${{ secrets.DOCKER_SSH_KEY }}
             -i ${{ secrets.DOCKER_HOST }}
             -e "ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,14 +45,11 @@ jobs:
         with:
           playbook: actions_test.yml
           directory: ansible
-          configuration: |
-            [defaults]
-            host_key_checking = False
-          inventory: |
-            ${{ secrets.DOCKER_HOST }}
           options: |
-            --extra-vars ansible_ssh_user=${{ secrets.DOCKER_USER }}
-            --extra-vars ansible_ssh_private_key_file=${{ secrets.DOCKER_SSH_KEY }}
+            -u ${{ secrets.DOCKER_USER }}
+            -v ${{ secrets.DOCKER_SSH_KEY }}
+            -i ${{ secrets.DOCKER_HOST }}
+            -e "ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
 
       - name: "Write YAML"
         id: yaml-action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,11 +37,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: "Install required tools"
-        run: sudo apt-get install apache2-utils
-
       - name: "Checkout"
         uses: actions/checkout@v4
+
+      - name: Run playbook
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: actions_test.yml
+          directory: ansible
+          configuration: |
+            [defaults]
+            host_key_checking = False
+          inventory: |
+            ${{ secrets.DOCKER_HOST }} ansible_ssh_user=${{ secrets.DOCKER_USER }} ansible_ssh_private_key_file=${{ secrets.DOCKER_SSH_KEY }}
 
       - name: "Write YAML"
         id: yaml-action
@@ -50,32 +58,13 @@ jobs:
           data: '{"version":"3.8","services":{"alpine":{"image":"localhost:5000/alpine","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
 
-      - name: "Create Registry User"
-        run: |
-          mkdir -p ./registry
-          htpasswd -Bbn testuser testpassword > ./registry/registry.password
-
-      - name: "Spool Private Docker Registry"
-        run: |
-          docker run -d -p 5000:5000 -e REGISTRY_AUTH="htpasswd" -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH="/auth/registry.password" -v ./registry/registry.password:/auth/registry.password --name registry registry:2
-
-      - name: "login to Registry"
-        run: |
-          echo testpassword | docker login localhost:5000 -u testuser --password-stdin
-
-      - name: "Push Image to Registry"
-        run: |
-          docker pull alpine
-          docker tag alpine localhost:5000/alpine
-          docker push localhost:5000/alpine
-
       - name: "Test Local Action with Registry Auth"
         id: test
         uses: ./
         with:
-          host: localhost
-          user: testuser
-          pass: testpassword
+          host: ${{ secrets.DOCKER_HOST }}
+          user: ${{ secrets.DOCKER_USER }}
+          ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
           file: "docker-compose.yaml"
           name: "test-private-stack"
           with_registry_auth: "true"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,7 @@ jobs:
             [defaults]
             host_key_checking = False
           inventory: |
+            [target]
             ${{ secrets.DOCKER_HOST }} ansible_ssh_user=${{ secrets.DOCKER_USER }} ansible_ssh_private_key_file=${{ secrets.DOCKER_SSH_KEY }}
 
       - name: "Write YAML"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Put private key in a file"
-        run: echo "${{ secrets.DOCKER_SSH_KEY }}" > ./ssh_key
+        run: |
+          echo "${{ secrets.DOCKER_SSH_KEY }}" > ./ssh_key
+          export ANSIBLE_HOST_KEY_CHECKING=False
 
       - name: Run playbook
         uses: dawidd6/action-ansible-playbook@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,8 +49,9 @@ jobs:
             [defaults]
             host_key_checking = False
           inventory: |
-            [target]
-            ${{ secrets.DOCKER_HOST }} ansible_ssh_user=${{ secrets.DOCKER_USER }} ansible_ssh_private_key_file=${{ secrets.DOCKER_SSH_KEY }}
+            ${{ secrets.DOCKER_HOST }}
+          options: |
+            --extra-vars ansible_ssh_user=${{ secrets.DOCKER_USER }} ansible_ssh_private_key_file=${{ secrets.DOCKER_SSH_KEY }}
 
       - name: "Write YAML"
         id: yaml-action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
+      - name: "Put private key in a file"
+        run: echo "${{ secrets.DOCKER_SSH_KEY }}" > ./ssh_key
+
       - name: Run playbook
         uses: dawidd6/action-ansible-playbook@v2
         with:
@@ -47,7 +50,7 @@ jobs:
           directory: ansible
           options: |
             -u ${{ secrets.DOCKER_USER }}
-            --private-key ${{ secrets.DOCKER_SSH_KEY }}
+            --private-key ./ssh_key
             -i ${{ secrets.DOCKER_HOST }}
             -e "ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
 

--- a/ansible/actions_test.yml
+++ b/ansible/actions_test.yml
@@ -3,11 +3,11 @@
   hosts: all
   become: no
   tasks:
-    - name: Ensure apache2-utils is present
-      apt:
-        name: apache2-utils
-        state: present
-        update_cache: yes
+    - name: Assert apache2-utils is present
+      command: dpkg -l apache2-utils
+      register: result
+      failed_when: result.rc != 0
+      changed_when: false
 
     - name: Create registry directory
       file:

--- a/ansible/actions_test.yml
+++ b/ansible/actions_test.yml
@@ -1,6 +1,6 @@
 ---
 - name: Test Registry Auth
-  hosts: all
+  hosts: target
   become: no
   tasks:
     - name: Ensure apache2-utils is present

--- a/ansible/actions_test.yml
+++ b/ansible/actions_test.yml
@@ -1,5 +1,6 @@
 ---
 - name: Test Registry Auth
+  hosts: all
   become: no
   tasks:
     - name: Ensure apache2-utils is present

--- a/ansible/actions_test.yml
+++ b/ansible/actions_test.yml
@@ -15,7 +15,8 @@
         state: directory
 
     - name: Create registry user
-      command: htpasswd -Bbn testuser testpassword > /tmp/registry/registry.password
+      shell: htpasswd -Bbn testuser testpassword > /tmp/registry/registry.password
+      changed_when: false
 
     - name: Create Docker registry container
       docker_container:

--- a/ansible/actions_test.yml
+++ b/ansible/actions_test.yml
@@ -1,0 +1,51 @@
+---
+- name: Test Registry Auth
+  become: no
+  tasks:
+    - name: Ensure apache2-utils is present
+      apt:
+        name: apache2-utils
+        state: present
+        update_cache: yes
+
+    - name: Create registry directory
+      file:
+        path: /tmp/registry
+        state: directory
+
+    - name: Create registry user
+      command: htpasswd -Bbn testuser testpassword > /tmp/registry/registry.password
+
+    - name: Create Docker registry container
+      docker_container:
+        name: registry
+        image: registry:2
+        ports:
+          - "5000:5000"
+        volumes:
+          - /tmp/registry/registry.password:/auth/registry.password:ro
+        env:
+          REGISTRY_AUTH: "htpasswd"
+          REGISTRY_AUTH_HTPASSWD_REALM: "Registry Realm"
+          REGISTRY_AUTH_HTPASSWD_PATH: "/auth/registry.password"
+        state: started
+
+    - name: Login to Docker registry
+      docker_login:
+        registry: localhost:5000
+        username: testuser
+        password: testpassword
+
+    - name: pull alpine image from Docker Hub
+      docker_image:
+        name: alpine
+        tag: latest
+        source: pull
+
+    - name: Push alpine image to local registry
+      docker_image:
+        name: alpine
+        repository: localhost:5000/alpine
+        tag: latest
+        push: true
+        source: local

--- a/ansible/actions_test.yml
+++ b/ansible/actions_test.yml
@@ -1,6 +1,6 @@
 ---
 - name: Test Registry Auth
-  hosts: target
+  hosts: all
   become: no
   tasks:
     - name: Ensure apache2-utils is present

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+host_key_checking = False

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,2 +1,0 @@
-[defaults]
-host_key_checking = False

--- a/src/main.sh
+++ b/src/main.sh
@@ -62,6 +62,7 @@ fi
 
 DEPLOY_CMD="docker stack deploy -c \"${INPUT_FILE}\" \"${INPUT_NAME}\""
 if [ "${INPUT_WITH_REGISTRY_AUTH}" == "true" ]; then
+    echo -e "\u001b[36mAdding with-registry-auth flag to command."
     DEPLOY_CMD="$DEPLOY_CMD --with-registry-auth"
 fi
 


### PR DESCRIPTION
Refactor the CI workflow to utilize an Ansible playbook for 
setting up a private Docker registry. Remove manual steps for 
installing tools and creating the registry, replacing them 
with automated tasks in the playbook. This enhances 
maintainability and reduces complexity in the workflow. 
Update secrets usage for improved security in registry 
authentication.